### PR TITLE
Trouble starting after docker build

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -31,6 +31,9 @@ ENV HOME=/root
 ENV LOGNAME=root
 ENV SHELL=/usr/sbin/bash
 ENV PATH=/lspf/src:$PATH
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
+RUN    /lspf/src/setup
 
 # Default command  when the container launches
 CMD bash

--- a/tools/docker/mkdirs.sh
+++ b/tools/docker/mkdirs.sh
@@ -5,8 +5,11 @@ cd /root/.lspf
 mkdir -p mlib
 mkdir -p tlib
 mkdir -p plib
+mkdir -p slib
+mkdir -p spool
+mkdir -p fldhist
 mkdir -p Apps
 mkdir -p Apps2
 mkdir -p rexx
-
+mkdir -p help/plib
 


### PR DESCRIPTION
/usr/local/lib is not scanned by ld by default in an Arch docker container, so lspf would fail to start

Also creating the additional user directories and running setup once during the docker build.