### PR TITLE
Fix copypaths -

### DIFF
--- a/tools/docker/copypaths.sh
+++ b/tools/docker/copypaths.sh
@@ -5,9 +5,11 @@ cd ../plib
 cp -r /lspf/plib/* .
 cd ../tlib
 cp /lspf/tlib/* .
+cp ISRKEYP ISRKEYS
 cd ../rexx
 cp /lspf/rexx/* .
 cd ../Apps
 cp /lspf/src/Apps/* .
-
+cd ../help/plib
+cp /lspf/help/plib/* .
 


### PR DESCRIPTION
This allows the help (and tutorials) to work

Creates the ISRKEYS file that's missing blocking editing / viewing of files